### PR TITLE
Config options for temperature wait parameters

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -840,6 +840,20 @@ max_temp:
 #   heater and sensor hardware failures. Set this range just wide
 #   enough so that reasonable temperatures do not result in an error.
 #   These parameters must be provided.
+#pid_settle_delta: 1.0
+#   The maximum delta between the set and measured (smoothed) temperature.
+#   This setting is used in conjunction with 'pid_settle_slope' to
+#   signal the heater has reached target temperature.
+#   Changing this should only be needed as a workaround for
+#   unstable temperatures in case of e.g noisy ADCs.
+#   Only used when the PID control algorithm is enabled.
+#   The default is 1.0 degrees Kelvin
+#pid_settle_slope: 0.1
+#   The maximum allowable (absolute) slope in temperature for the
+#   heater to signal that it reached target temperature.
+#   The smaller the value, the more the temperature needs to stabilize
+#   Used in conjuntion with 'pid_settle_delta'.
+#   The default is 0.1
 ```
 
 ### [heater_bed]

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -169,9 +169,6 @@ class ControlBangBang:
 # Proportional Integral Derivative (PID) control algo
 ######################################################################
 
-PID_SETTLE_DELTA = 1.
-PID_SETTLE_SLOPE = .1
-
 class ControlPID:
     def __init__(self, heater, config):
         self.heater = heater
@@ -179,6 +176,8 @@ class ControlPID:
         self.Kp = config.getfloat('pid_Kp') / PID_PARAM_BASE
         self.Ki = config.getfloat('pid_Ki') / PID_PARAM_BASE
         self.Kd = config.getfloat('pid_Kd') / PID_PARAM_BASE
+        self.settle_delta = config.getfloat('pid_settle_delta', 1.0, above=0.)
+        self.settle_slope = config.getfloat('pid_settle_slope', .1, above=0.)
         self.min_deriv_time = heater.get_smooth_time()
         self.temp_integ_max = 0.
         if self.Ki:
@@ -214,8 +213,8 @@ class ControlPID:
             self.prev_temp_integ = temp_integ
     def check_busy(self, eventtime, smoothed_temp, target_temp):
         temp_diff = target_temp - smoothed_temp
-        return (abs(temp_diff) > PID_SETTLE_DELTA
-                or abs(self.prev_temp_deriv) > PID_SETTLE_SLOPE)
+        return (abs(temp_diff) > self.settle_delta
+                or abs(self.prev_temp_deriv) > self.settle_slope)
 
 
 ######################################################################


### PR DESCRIPTION
I added the possibility to change the previous constants PID_SETTLE_DELTA and PID_SETTLE_SLOPE through the config file.
This gives users with noisy temperature readings a possibility to use the "wait for temperature" functionality (M109 etc.) by changing those parameters.